### PR TITLE
fix: unexpected token 'return', expected one of token or <phrase> sequence

### DIFF
--- a/src/motoko_http_handler/main.mo
+++ b/src/motoko_http_handler/main.mo
@@ -77,7 +77,7 @@ actor {
         if(path == "/big_file") {
             // TODO: example of response with streaming_strategy
             // that returns a large file in streaming mode
-        }
+        };
 
 
         return {


### PR DESCRIPTION
A `;` is missing so the last `return` cannot be reached.